### PR TITLE
Add minimal presence sharing demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# Appmake
+# Presence App
+
+Minimal demo of the "ここいる" presence-sharing concept.
+
+## Usage
+
+1. Start the WebSocket server:
+   ```bash
+   node server.js
+   ```
+2. Open `index.html` in one or more browser windows.
+3. Select a color at the bottom to change your vibe. Dots for other visitors fade in as they join.
+
+The interface is PWA-ready and works offline after first load.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>ここいる Presence</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <div id="topbar">
+    <span id="room-name"></span>
+    <button id="share-btn">Share</button>
+  </div>
+  <canvas id="presence-canvas"></canvas>
+  <div id="status"></div>
+  <div id="vibe-picker">
+    <button class="vibe calm" data-vibe="calm" aria-label="calm"></button>
+    <button class="vibe sunny" data-vibe="sunny" aria-label="sunny"></button>
+    <button class="vibe deep" data-vibe="deep" aria-label="deep"></button>
+    <button class="vibe free" data-vibe="free" aria-label="free"></button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "ここいる Presence",
+  "short_name": "ここいる",
+  "display": "standalone",
+  "start_url": "./",
+  "icons": []
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "appmake",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,105 @@
+const canvas = document.getElementById('presence-canvas');
+const ctx = canvas.getContext('2d');
+let width, height;
+function resize() {
+  width = canvas.width = window.innerWidth;
+  height = canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+const vibes = {
+  calm: '#6ba4ff',
+  sunny: '#ffe66b',
+  deep: '#b36bff',
+  free: '#6bffb3'
+};
+let currentVibe = 'calm';
+
+document.querySelectorAll('.vibe').forEach(btn => {
+  btn.addEventListener('click', () => {
+    currentVibe = btn.dataset.vibe;
+    document.querySelectorAll('.vibe').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+    send({ type: 'setVibe', vibe: currentVibe });
+  });
+});
+document.querySelector('.vibe.calm').classList.add('selected');
+
+const roomId = location.pathname.replace('/', '') || 'default';
+document.getElementById('room-name').textContent = `room: ${roomId}`;
+
+let token = localStorage.getItem('anonToken');
+if (!token) {
+  token = crypto.randomUUID();
+  localStorage.setItem('anonToken', token);
+}
+
+const ws = new WebSocket('ws://localhost:8080');
+ws.addEventListener('open', () => {
+  send({ type: 'join', room: roomId, token, vibe: currentVibe });
+});
+ws.addEventListener('message', ev => {
+  const data = JSON.parse(ev.data);
+  if (data.type === 'snapshot') {
+    const active = {};
+    data.clients.forEach(c => {
+      if (!points[c.id]) {
+        points[c.id] = { x: Math.random(), y: Math.random(), vibe: c.vibe };
+      } else {
+        points[c.id].vibe = c.vibe;
+      }
+      active[c.id] = true;
+    });
+    for (const id in points) {
+      if (!active[id]) delete points[id];
+    }
+    updateStatus();
+  }
+});
+ws.addEventListener('close', () => updateStatus());
+
+function send(msg) {
+  if (ws.readyState === 1) ws.send(JSON.stringify(msg));
+}
+
+const points = {};
+points[token] = { x: Math.random(), y: Math.random(), vibe: currentVibe };
+
+function updateStatus() {
+  const count = Object.keys(points).length;
+  let text = 'いま、静か。';
+  if (count > 1 && count < 3) text = 'いま、だれかがいる。';
+  if (count >= 3) text = 'いま、いくつかの灯りがともっている。';
+  document.getElementById('status').textContent = text;
+}
+updateStatus();
+
+function draw() {
+  ctx.clearRect(0, 0, width, height);
+  for (const id in points) {
+    const p = points[id];
+    const x = p.x * width;
+    const y = p.y * height;
+    ctx.beginPath();
+    ctx.arc(x, y, 8, 0, Math.PI * 2);
+    ctx.fillStyle = vibes[p.vibe] || '#fff';
+    ctx.fill();
+  }
+  requestAnimationFrame(draw);
+}
+draw();
+
+document.getElementById('share-btn').addEventListener('click', () => {
+  const url = location.href;
+  if (navigator.share) {
+    navigator.share({ url });
+  } else if (navigator.clipboard) {
+    navigator.clipboard.writeText(url);
+    alert('URL copied');
+  }
+});
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('sw.js');
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,107 @@
+const http = require('http');
+const crypto = require('crypto');
+
+const server = http.createServer();
+const PORT = 8080;
+
+const rooms = new Map();
+
+server.on('upgrade', (req, socket) => {
+  if (req.headers['upgrade'] !== 'websocket') {
+    socket.end('HTTP/1.1 400 Bad Request');
+    return;
+  }
+  const acceptKey = req.headers['sec-websocket-key'];
+  const hash = crypto
+    .createHash('sha1')
+    .update(acceptKey + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+    .digest('base64');
+  const headers = [
+    'HTTP/1.1 101 Switching Protocols',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Accept: ${hash}`
+  ];
+  socket.write(headers.concat('\r\n').join('\r\n'));
+  socket.id = crypto.randomUUID();
+  socket.on('data', buffer => handleMessage(socket, decode(buffer)));
+  socket.on('end', () => handleClose(socket));
+  socket.on('error', () => handleClose(socket));
+});
+
+function decode(buffer) {
+  const secondByte = buffer[1];
+  const length = secondByte & 127;
+  let offset = 2;
+  if (length === 126) {
+    offset = 4;
+  } else if (length === 127) {
+    offset = 10;
+  }
+  const masks = buffer.slice(offset, offset + 4);
+  offset += 4;
+  const data = buffer.slice(offset);
+  for (let i = 0; i < data.length; i++) {
+    data[i] ^= masks[i % 4];
+  }
+  return data.toString('utf8');
+}
+
+function encode(str) {
+  const json = Buffer.from(str);
+  const length = json.length;
+  let header;
+  if (length < 126) {
+    header = Buffer.from([0x81, length]);
+  } else if (length < 65536) {
+    header = Buffer.from([0x81, 126, (length >> 8) & 255, length & 255]);
+  } else {
+    header = Buffer.from([0x81, 127, 0, 0, 0, 0, (length >> 24) & 255, (length >> 16) & 255, (length >> 8) & 255, length & 255]);
+  }
+  return Buffer.concat([header, json]);
+}
+
+function handleMessage(socket, message) {
+  let data;
+  try {
+    data = JSON.parse(message);
+  } catch (e) {
+    return;
+  }
+  if (data.type === 'join') {
+    const roomId = data.room;
+    socket.roomId = roomId;
+    socket.token = data.token;
+    socket.vibe = data.vibe || 'calm';
+    if (!rooms.has(roomId)) rooms.set(roomId, new Map());
+    rooms.get(roomId).set(socket.token, socket);
+    broadcast(roomId);
+  } else if (data.type === 'setVibe') {
+    if (socket.roomId && rooms.get(socket.roomId)) {
+      socket.vibe = data.vibe;
+      broadcast(socket.roomId);
+    }
+  }
+}
+
+function handleClose(socket) {
+  if (socket.roomId && rooms.get(socket.roomId)) {
+    rooms.get(socket.roomId).delete(socket.token);
+    broadcast(socket.roomId);
+  }
+}
+
+function broadcast(roomId) {
+  const room = rooms.get(roomId);
+  if (!room) return;
+  const clients = [];
+  room.forEach(s => {
+    clients.push({ id: s.token, vibe: s.vibe });
+  });
+  const msg = encode(JSON.stringify({ type: 'snapshot', clients }));
+  room.forEach(s => s.write(msg));
+}
+
+server.listen(PORT, () => {
+  console.log('Presence server running on port', PORT);
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,57 @@
+html, body {
+  margin: 0;
+  height: 100%;
+  background: #111;
+  color: #fff;
+  font-family: sans-serif;
+}
+#topbar {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 10px;
+  z-index: 2;
+}
+#presence-canvas {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 100%;
+  background: #111;
+}
+#status {
+  position: absolute;
+  top: 50px;
+  width: 100%;
+  text-align: center;
+  font-size: 18px;
+  z-index: 2;
+}
+#vibe-picker {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 15px;
+  z-index: 2;
+}
+.vibe {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  opacity: 0.8;
+}
+.vibe.calm { background: #6ba4ff; }
+.vibe.sunny { background: #ffe66b; }
+.vibe.deep { background: #b36bff; }
+.vibe.free { background: #6bffb3; }
+.vibe.selected {
+  outline: 3px solid #fff;
+  opacity: 1;
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,14 @@
+const CACHE_NAME = 'presence-cache-v1';
+const ASSETS = [
+  './',
+  'index.html',
+  'style.css',
+  'script.js',
+  'manifest.json'
+];
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS)));
+});
+self.addEventListener('fetch', e => {
+  e.respondWith(caches.match(e.request).then(res => res || fetch(e.request)));
+});


### PR DESCRIPTION
## Summary
- build minimal "ここいる" prototype with canvas dots and vibe color picker
- implement barebones WebSocket server for real-time presence
- add PWA manifest and service worker for offline caching

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68b5a66517a48321ae714abcb7bf0f8c