### PR TITLE
Add heartbeat and offline fallback for presence app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# Appmake
+# Presence App
+
+Minimal demo of the "ここいる" presence-sharing concept.
+
+## Usage
+
+1. Start the WebSocket server:
+   ```bash
+   node server.js
+   ```
+2. Open `index.html` in one or more browser windows.
+3. Select a color at the bottom to change your vibe. Dots for other visitors fade in as they join.
+
+The interface is PWA-ready and works offline after first load.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Minimal demo of the "ここいる" presence-sharing concept.
 
 ## Usage
 
-1. Start the WebSocket server:
+1. Start the server:
    ```bash
    node server.js
    ```
-2. Open `index.html` in one or more browser windows.
+2. Visit `http://localhost:8080/` in one or more browser windows.
 3. Select a color at the bottom to change your vibe. Dots for other visitors fade in as they join.
 
 The interface is PWA-ready and works offline after first load.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>ここいる Presence</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <div id="topbar">
+    <span id="room-name"></span>
+    <button id="share-btn">Share</button>
+  </div>
+  <canvas id="presence-canvas"></canvas>
+  <div id="status"></div>
+  <div id="vibe-picker">
+    <button class="vibe calm" data-vibe="calm" aria-label="calm"></button>
+    <button class="vibe sunny" data-vibe="sunny" aria-label="sunny"></button>
+    <button class="vibe deep" data-vibe="deep" aria-label="deep"></button>
+    <button class="vibe free" data-vibe="free" aria-label="free"></button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "ここいる Presence",
+  "short_name": "ここいる",
+  "display": "standalone",
+  "start_url": "./",
+  "icons": []
+}

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>オフライン</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body{display:flex;align-items:center;justify-content:center;height:100vh;background:#111;color:#fff;font-family:sans-serif;}
+</style>
+</head>
+<body>
+<div>静かな待合表示</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "appmake",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -24,7 +24,8 @@ document.getElementById('room-name').textContent=`room: ${roomId}`;
 let token=localStorage.getItem('anonToken');
 if(!token){token=crypto.randomUUID();localStorage.setItem('anonToken',token);}
 
-const ws=new WebSocket('ws://localhost:8080');
+const wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host;
+const ws = new WebSocket(wsUrl);
 ws.addEventListener('open',()=>{
   send({type:'join',room:roomId,token,vibe:currentVibe});
   heartbeat();

--- a/script.js
+++ b/script.js
@@ -1,0 +1,100 @@
+const canvas = document.getElementById('presence-canvas');
+const ctx = canvas.getContext('2d');
+let width, height;
+function resize(){width=canvas.width=window.innerWidth;height=canvas.height=window.innerHeight;}
+window.addEventListener('resize',resize);resize();
+
+const vibes={calm:'#6ba4ff',sunny:'#ffe66b',deep:'#b36bff',free:'#6bffb3'};
+let currentVibe='calm';
+
+document.querySelectorAll('.vibe').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    currentVibe=btn.dataset.vibe;
+    document.querySelectorAll('.vibe').forEach(b=>b.classList.remove('selected'));
+    btn.classList.add('selected');
+    if(points[token]) points[token].vibe=currentVibe;
+    send({type:'setVibe',vibe:currentVibe});
+  });
+});
+document.querySelector('.vibe.calm').classList.add('selected');
+
+const roomId=location.pathname.replace('/','')||'default';
+document.getElementById('room-name').textContent=`room: ${roomId}`;
+
+let token=localStorage.getItem('anonToken');
+if(!token){token=crypto.randomUUID();localStorage.setItem('anonToken',token);}
+
+const ws=new WebSocket('ws://localhost:8080');
+ws.addEventListener('open',()=>{
+  send({type:'join',room:roomId,token,vibe:currentVibe});
+  heartbeat();
+});
+ws.addEventListener('message',ev=>{
+  const data=JSON.parse(ev.data);
+  if(data.type==='snapshot'){
+    const active={};
+    data.clients.forEach(c=>{
+      if(!points[c.id]) points[c.id]=createPoint(c.vibe);
+      points[c.id].vibe=c.vibe;
+      points[c.id].targetAlpha=1;
+      points[c.id].removing=false;
+      active[c.id]=true;
+    });
+    for(const id in points){
+      if(!active[id]){
+        points[id].targetAlpha=0;
+        points[id].removing=true;
+      }
+    }
+    updateStatus();
+  }
+});
+ws.addEventListener('close',()=>updateStatus());
+function send(msg){if(ws.readyState===1) ws.send(JSON.stringify(msg));}
+
+const points={};
+points[token]=createPoint(currentVibe);
+updateStatus();
+
+function createPoint(vibe){return{ x:Math.random(), y:Math.random(), vibe, alpha:0, targetAlpha:1, born:performance.now(), removing:false};}
+
+function updateStatus(){
+  const count=Object.keys(points).filter(id=>points[id].targetAlpha>0).length;
+  let text='いま、静か。';
+  if(count>1 && count<3) text='いま、だれかがいる。';
+  if(count>=3) text='いま、いくつかの灯りがともっている。';
+  document.getElementById('status').textContent=text;
+}
+
+function draw(now){
+  ctx.clearRect(0,0,width,height);
+  for(const id in points){
+    const p=points[id];
+    p.alpha+= (p.targetAlpha-p.alpha)*0.05;
+    if(p.removing && p.alpha<0.01){delete points[id];continue;}
+    const x=p.x*width;
+    const y=p.y*height;
+    const radius=8*(1+0.2*Math.sin((now-p.born)/1000));
+    ctx.globalAlpha=p.alpha;
+    ctx.beginPath();
+    ctx.arc(x,y,radius,0,Math.PI*2);
+    ctx.fillStyle=vibes[p.vibe]||'#fff';
+    ctx.fill();
+    ctx.globalAlpha=1;
+  }
+  requestAnimationFrame(draw);
+}
+requestAnimationFrame(draw);
+
+function heartbeat(){
+  send({type:'heartbeat',room:roomId,token});
+  setTimeout(heartbeat,5000);
+}
+
+document.getElementById('share-btn').addEventListener('click',()=>{
+  const url=location.href;
+  if(navigator.share){navigator.share({url});}
+  else if(navigator.clipboard){navigator.clipboard.writeText(url);alert('URL copied');}
+});
+
+if('serviceWorker' in navigator){navigator.serviceWorker.register('sw.js');}

--- a/server.js
+++ b/server.js
@@ -1,79 +1,111 @@
-const http=require('http');
-const crypto=require('crypto');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
 
-const server=http.createServer();
-const PORT=8080;
+const PORT = 8080;
+const rooms = new Map();
 
-const rooms=new Map();
+const mime = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.json': 'application/json'
+};
 
-server.on('upgrade',(req,socket)=>{
-  if(req.headers['upgrade']!=='websocket'){socket.end('HTTP/1.1 400 Bad Request');return;}
-  const acceptKey=req.headers['sec-websocket-key'];
-  const hash=crypto.createHash('sha1').update(acceptKey+'258EAFA5-E914-47DA-95CA-C5AB0DC85B11').digest('base64');
-  const headers=['HTTP/1.1 101 Switching Protocols','Upgrade: websocket','Connection: Upgrade',`Sec-WebSocket-Accept: ${hash}`];
-  socket.write(headers.concat('\r\n').join('\r\n'));
-  socket.id=crypto.randomUUID();
-  socket.on('data',buffer=>handleMessage(socket,decode(buffer)));
-  socket.on('end',()=>handleClose(socket));
-  socket.on('error',()=>handleClose(socket));
+const server = http.createServer((req, res) => {
+  const url = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(__dirname, url);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      res.writeHead(200, { 'Content-Type': mime[path.extname(filePath)] || 'text/plain' });
+      res.end(data);
+    }
+  });
 });
 
-function decode(buffer){
-  const secondByte=buffer[1];
-  const length=secondByte&127;
-  let offset=2;
-  if(length===126) offset=4; else if(length===127) offset=10;
-  const masks=buffer.slice(offset,offset+4);offset+=4;
-  const data=buffer.slice(offset);
-  for(let i=0;i<data.length;i++){data[i]^=masks[i%4];}
+server.on('upgrade', (req, socket) => {
+  if (req.headers['upgrade'] !== 'websocket') {
+    socket.end('HTTP/1.1 400 Bad Request');
+    return;
+  }
+  const acceptKey = req.headers['sec-websocket-key'];
+  const hash = crypto
+    .createHash('sha1')
+    .update(acceptKey + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+    .digest('base64');
+  const headers = [
+    'HTTP/1.1 101 Switching Protocols',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Accept: ${hash}`
+  ];
+  socket.write(headers.concat('\r\n').join('\r\n'));
+  socket.id = crypto.randomUUID();
+  socket.on('data', buf => handleMessage(socket, decode(buf)));
+  socket.on('end', () => handleClose(socket));
+  socket.on('error', () => handleClose(socket));
+});
+
+function decode(buffer) {
+  const secondByte = buffer[1];
+  const length = secondByte & 127;
+  let offset = 2;
+  if (length === 126) offset = 4; else if (length === 127) offset = 10;
+  const masks = buffer.slice(offset, offset + 4); offset += 4;
+  const data = buffer.slice(offset);
+  for (let i = 0; i < data.length; i++) data[i] ^= masks[i % 4];
   return data.toString('utf8');
 }
-function encode(str){
-  const json=Buffer.from(str);const length=json.length;let header;
-  if(length<126){header=Buffer.from([0x81,length]);}
-  else if(length<65536){header=Buffer.from([0x81,126,(length>>8)&255,length&255]);}
-  else{header=Buffer.from([0x81,127,0,0,0,0,(length>>24)&255,(length>>16)&255,(length>>8)&255,length&255]);}
-  return Buffer.concat([header,json]);
+function encode(str) {
+  const json = Buffer.from(str); const length = json.length; let header;
+  if (length < 126) header = Buffer.from([0x81, length]);
+  else if (length < 65536) header = Buffer.from([0x81, 126, (length >> 8) & 255, length & 255]);
+  else header = Buffer.from([0x81, 127, 0, 0, 0, 0, (length >> 24) & 255, (length >> 16) & 255, (length >> 8) & 255, length & 255]);
+  return Buffer.concat([header, json]);
 }
 
-function handleMessage(socket,message){
-  let data;try{data=JSON.parse(message);}catch(e){return;}
-  if(data.type==='join'){
-    const roomId=data.room;socket.roomId=roomId;socket.token=data.token;socket.vibe=data.vibe||'calm';socket.lastSeen=Date.now();
-    if(!rooms.has(roomId)) rooms.set(roomId,new Map());
-    rooms.get(roomId).set(socket.token,socket);
+function handleMessage(socket, message) {
+  let data; try { data = JSON.parse(message); } catch { return; }
+  if (data.type === 'join') {
+    const roomId = data.room; socket.roomId = roomId; socket.token = data.token; socket.vibe = data.vibe || 'calm'; socket.lastSeen = Date.now();
+    if (!rooms.has(roomId)) rooms.set(roomId, new Map());
+    rooms.get(roomId).set(socket.token, socket);
     broadcast(roomId);
-  }else if(data.type==='setVibe'){
-    if(socket.roomId&&rooms.get(socket.roomId)){
-      socket.vibe=data.vibe;broadcast(socket.roomId);
+  } else if (data.type === 'setVibe') {
+    if (socket.roomId && rooms.get(socket.roomId)) {
+      socket.vibe = data.vibe; broadcast(socket.roomId);
     }
-  }else if(data.type==='heartbeat'){
-    socket.lastSeen=Date.now();
+  } else if (data.type === 'heartbeat') {
+    socket.lastSeen = Date.now();
   }
 }
 
-function handleClose(socket){
-  if(socket.roomId&&rooms.get(socket.roomId)){
+function handleClose(socket) {
+  if (socket.roomId && rooms.get(socket.roomId)) {
     rooms.get(socket.roomId).delete(socket.token);
     broadcast(socket.roomId);
   }
 }
 
-function broadcast(roomId){
-  const room=rooms.get(roomId);if(!room) return;
-  const clients=[];room.forEach(s=>{clients.push({id:s.token,vibe:s.vibe});});
-  const msg=encode(JSON.stringify({type:'snapshot',clients}));
-  room.forEach(s=>s.write(msg));
+function broadcast(roomId) {
+  const room = rooms.get(roomId); if (!room) return;
+  const clients = []; room.forEach(s => { clients.push({ id: s.token, vibe: s.vibe }); });
+  const msg = encode(JSON.stringify({ type: 'snapshot', clients }));
+  room.forEach(s => s.write(msg));
 }
 
-setInterval(()=>{
-  const now=Date.now();
-  rooms.forEach((room,roomId)=>{
-    room.forEach((socket,token)=>{
-      if(now-socket.lastSeen>15000){room.delete(token);try{socket.end();}catch{};}
+setInterval(() => {
+  const now = Date.now();
+  rooms.forEach((room, roomId) => {
+    room.forEach((socket, token) => {
+      if (now - socket.lastSeen > 15000) { room.delete(token); try { socket.end(); } catch { } }
     });
     broadcast(roomId);
   });
-},10000);
+}, 10000);
 
-server.listen(PORT,()=>{console.log('Presence server running on port',PORT);});
+server.listen(PORT, () => console.log('Presence server running on port', PORT));

--- a/server.js
+++ b/server.js
@@ -1,0 +1,79 @@
+const http=require('http');
+const crypto=require('crypto');
+
+const server=http.createServer();
+const PORT=8080;
+
+const rooms=new Map();
+
+server.on('upgrade',(req,socket)=>{
+  if(req.headers['upgrade']!=='websocket'){socket.end('HTTP/1.1 400 Bad Request');return;}
+  const acceptKey=req.headers['sec-websocket-key'];
+  const hash=crypto.createHash('sha1').update(acceptKey+'258EAFA5-E914-47DA-95CA-C5AB0DC85B11').digest('base64');
+  const headers=['HTTP/1.1 101 Switching Protocols','Upgrade: websocket','Connection: Upgrade',`Sec-WebSocket-Accept: ${hash}`];
+  socket.write(headers.concat('\r\n').join('\r\n'));
+  socket.id=crypto.randomUUID();
+  socket.on('data',buffer=>handleMessage(socket,decode(buffer)));
+  socket.on('end',()=>handleClose(socket));
+  socket.on('error',()=>handleClose(socket));
+});
+
+function decode(buffer){
+  const secondByte=buffer[1];
+  const length=secondByte&127;
+  let offset=2;
+  if(length===126) offset=4; else if(length===127) offset=10;
+  const masks=buffer.slice(offset,offset+4);offset+=4;
+  const data=buffer.slice(offset);
+  for(let i=0;i<data.length;i++){data[i]^=masks[i%4];}
+  return data.toString('utf8');
+}
+function encode(str){
+  const json=Buffer.from(str);const length=json.length;let header;
+  if(length<126){header=Buffer.from([0x81,length]);}
+  else if(length<65536){header=Buffer.from([0x81,126,(length>>8)&255,length&255]);}
+  else{header=Buffer.from([0x81,127,0,0,0,0,(length>>24)&255,(length>>16)&255,(length>>8)&255,length&255]);}
+  return Buffer.concat([header,json]);
+}
+
+function handleMessage(socket,message){
+  let data;try{data=JSON.parse(message);}catch(e){return;}
+  if(data.type==='join'){
+    const roomId=data.room;socket.roomId=roomId;socket.token=data.token;socket.vibe=data.vibe||'calm';socket.lastSeen=Date.now();
+    if(!rooms.has(roomId)) rooms.set(roomId,new Map());
+    rooms.get(roomId).set(socket.token,socket);
+    broadcast(roomId);
+  }else if(data.type==='setVibe'){
+    if(socket.roomId&&rooms.get(socket.roomId)){
+      socket.vibe=data.vibe;broadcast(socket.roomId);
+    }
+  }else if(data.type==='heartbeat'){
+    socket.lastSeen=Date.now();
+  }
+}
+
+function handleClose(socket){
+  if(socket.roomId&&rooms.get(socket.roomId)){
+    rooms.get(socket.roomId).delete(socket.token);
+    broadcast(socket.roomId);
+  }
+}
+
+function broadcast(roomId){
+  const room=rooms.get(roomId);if(!room) return;
+  const clients=[];room.forEach(s=>{clients.push({id:s.token,vibe:s.vibe});});
+  const msg=encode(JSON.stringify({type:'snapshot',clients}));
+  room.forEach(s=>s.write(msg));
+}
+
+setInterval(()=>{
+  const now=Date.now();
+  rooms.forEach((room,roomId)=>{
+    room.forEach((socket,token)=>{
+      if(now-socket.lastSeen>15000){room.delete(token);try{socket.end();}catch{};}
+    });
+    broadcast(roomId);
+  });
+},10000);
+
+server.listen(PORT,()=>{console.log('Presence server running on port',PORT);});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,57 @@
+html, body {
+  margin: 0;
+  height: 100%;
+  background: #111;
+  color: #fff;
+  font-family: sans-serif;
+}
+#topbar {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 10px;
+  z-index: 2;
+}
+#presence-canvas {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 100%;
+  background: #111;
+}
+#status {
+  position: absolute;
+  top: 50px;
+  width: 100%;
+  text-align: center;
+  font-size: 18px;
+  z-index: 2;
+}
+#vibe-picker {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 15px;
+  z-index: 2;
+}
+.vibe {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  opacity: 0.8;
+}
+.vibe.calm { background: #6ba4ff; }
+.vibe.sunny { background: #ffe66b; }
+.vibe.deep { background: #b36bff; }
+.vibe.free { background: #6bffb3; }
+.vibe.selected {
+  outline: 3px solid #fff;
+  opacity: 1;
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,21 @@
+const CACHE_NAME = 'presence-cache-v2';
+const ASSETS = [
+  './',
+  'index.html',
+  'style.css',
+  'script.js',
+  'manifest.json',
+  'offline.html'
+];
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS)));
+});
+self.addEventListener('fetch', e => {
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      fetch(e.request).catch(() => caches.match('offline.html'))
+    );
+  } else {
+    e.respondWith(caches.match(e.request).then(res => res || fetch(e.request)));
+  }
+});


### PR DESCRIPTION
## Summary
- animate presence dots with fade and breathing effect
- maintain active clients via heartbeat and cleanup logic
- serve offline waiting screen through updated service worker

## Testing
- `node server.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5a66517a48321ae714abcb7bf0f8c